### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -4,7 +4,7 @@ import { Router, RouteLocationNormalizedLoaded } from 'vue-router'
 import { Store } from 'vuex'
 
 /** 将第三方变量挂载到每一个 vue 示例中  */
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $message: Message
     $store: Store<StateType>


### PR DESCRIPTION
For a while, in the Vue ecosystem we've been augmenting `@vue/runtime-core` to add custom properties and more to `vue`. However, this inadvertently breaks the types for projects that augment `vue` - which is (now?) the officially recommended in the docs way to augment these interfaces (for example, [ComponentCustomProperties](https://vuejs.org/api/utility-types.html#componentcustomproperties), [GlobalComponents](https://vuejs.org/guide/extras/web-components.html#web-components-and-typescript) and [so on](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties)).

This means _all_ libraries must update their code (or it will break the types of the libraries that augment `vue` instead).

[Here's an example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgYygUwIYzQQTGOAXzgDMoIQ4ByANwFc0qAoJ5CAOwGd4N84BeFOiy58ACgSEAlCwD0suAAEYnALRoAHmDTIY6qOShwARhiOcAFhDoAbACYm0cGAE9tDjJ2owoDZmy54AH0MAC44djoQYzQjQV4wADoAkmAAc0S0mwhTGwAFcm1YYDRORNMoOQVlNU1tXX1DUggIOEtre0dnNzQPLyofP1YObjgg43DI6NiBOATkjlSMrJyMfMLYmBKykhaWOx0bMycQCDtbJ1o-RCY4OGB2bCgSDGQnAGEKSHY0R-e6bgUAoQIpbUo3O53XYQcKDNC3IhMQj7Q7HOCnc42S6KehoWS+R6gNCqNjoKgQ+6PWIvN5wT7gDi-GD-QEgYGg7YUu4VWG+eF3ZGEIA) of how the augmented types end up broken.

This PR is a small effort to ensure the ecosystem is consistent. For context, you can see that `vue-router` has [moved to do this](https://github.com/vuejs/router/pull/2295), as well as [Nuxt](https://github.com/nuxt/nuxt/pull/28542).